### PR TITLE
Fix issue with config.php

### DIFF
--- a/src/Anchu/Ftp/FtpServiceProvider.php
+++ b/src/Anchu/Ftp/FtpServiceProvider.php
@@ -19,7 +19,7 @@ class FtpServiceProvider extends ServiceProvider {
 	public function boot()
 	{
 		 $this->publishes([
-            __DIR__.'/../../config/config.php' => config_path('ftp.php'),
+            __DIR__.'/../../config/ftp.php' => config_path('ftp.php'),
         ]);
 	}
 


### PR DESCRIPTION
The server provider look for a config.php file who doens't exist in the config folder.

Can't locate path: <ftp-test/vendor/rikless/laravel-ftp/src/Anchu/Ftp/../../config/config.php>
